### PR TITLE
ensure spot price example uses lower case when comparing addresses

### DIFF
--- a/examples/spotPrice.ts
+++ b/examples/spotPrice.ts
@@ -24,15 +24,15 @@ import { getUnitSeconds } from "../src/helpers/getUnitSeconds";
 
 async function main() {
   const balVault = "0x65748E8287Ce4B9E6D83EE853431958851550311"; // balancer vault address
-  const base = "0x9A1000D492d40bfccbc03f413A48F5B6516Ec0Fd"; // base token address
+  const base = "0x9A1000D492d40bfccbc03f413A48F5B6516Ec0Fd".toLowerCase(); // base token address
   const [signer] = await ethers.getSigners();
 
   // calculate principal token spot price
   const ptPool = "0x9eB7F54C0eCc4d0D2dfF28a1276e36d598F2B0D1"; // principal token Pool address
   const totalSupply = await getTotalSupply(ptPool, signer);
   let reserves = await getReserves(ptPool, balVault, signer);
-  const ptIndex = reserves.tokens[0] == base ? 1 : 0;
-  let baseIndex = reserves.tokens[0] == base ? 0 : 1;
+  const ptIndex = reserves.tokens[0].toLowerCase() == base ? 1 : 0;
+  let baseIndex = reserves.tokens[0].toLowerCase() == base ? 0 : 1;
   const ptReserves = reserves.balances[ptIndex];
   let baseReserves = reserves.balances[baseIndex];
   const blockTimestamp = await getLatestBlockTimestamp();
@@ -60,8 +60,8 @@ async function main() {
   // calculate yield token spot price
   const ytPool = "0xD75bfF2444FF738d443066ff4688691e6852b217"; // yield token Pool address
   reserves = await getReserves(ytPool, balVault, signer);
-  const ytIndex = reserves.tokens[0] == base ? 1 : 0;
-  baseIndex = reserves.tokens[0] == base ? 0 : 1;
+  const ytIndex = reserves.tokens[0].toLowerCase() == base ? 1 : 0;
+  baseIndex = reserves.tokens[0].toLowerCase() == base ? 0 : 1;
   const ytReserves = reserves.balances[ytIndex];
   baseReserves = reserves.balances[baseIndex];
   const ytSpotPrice = calcSpotPriceYt(


### PR DESCRIPTION
sometimes prices were being calculated incorrectly based on the format of the base token used in the example.