### PR TITLE
Fix spot price bug, add method for base addresses

### DIFF
--- a/examples/poolDetails.ts
+++ b/examples/poolDetails.ts
@@ -50,7 +50,7 @@ async function main() {
     totalSupply.toString(),
     timeRemainingSeconds,
     unitSeconds,
-    ptDecimals[ptIndex]
+   baseDecimals
   );
   console.log("\nPrincipal Token");
   console.log(`totalSupply: ${totalSupply}`);

--- a/examples/poolDetails.ts
+++ b/examples/poolDetails.ts
@@ -36,6 +36,7 @@ async function main() {
   let baseIndex = reserves.tokens[0].toLowerCase() == base ? 0 : 1;
   const ptReserves = reserves.balances[ptIndex];
   let baseReserves = reserves.balances[baseIndex];
+  const ptDecimals = reserves.decimals;
   const blockTimestamp = await getLatestBlockTimestamp();
   const timeRemainingSeconds = await getTimeUntilExpiration(
     ptPool,
@@ -48,7 +49,8 @@ async function main() {
     ptReserves.toString(),
     totalSupply.toString(),
     timeRemainingSeconds,
-    unitSeconds
+    unitSeconds,
+    ptDecimals[0]
   );
   console.log("\nPrincipal Token");
   console.log(`totalSupply: ${totalSupply}`);

--- a/examples/poolDetails.ts
+++ b/examples/poolDetails.ts
@@ -50,7 +50,7 @@ async function main() {
     totalSupply.toString(),
     timeRemainingSeconds,
     unitSeconds,
-   baseDecimals
+    baseDecimals
   );
   console.log("\nPrincipal Token");
   console.log(`totalSupply: ${totalSupply}`);

--- a/examples/poolDetails.ts
+++ b/examples/poolDetails.ts
@@ -36,7 +36,7 @@ async function main() {
   let baseIndex = reserves.tokens[0].toLowerCase() == base ? 0 : 1;
   const ptReserves = reserves.balances[ptIndex];
   let baseReserves = reserves.balances[baseIndex];
-  const ptDecimals = reserves.decimals;
+  const baseDecimals = reserves.decimals[baseIndex];
   const blockTimestamp = await getLatestBlockTimestamp();
   const timeRemainingSeconds = await getTimeUntilExpiration(
     ptPool,

--- a/examples/poolDetails.ts
+++ b/examples/poolDetails.ts
@@ -50,7 +50,7 @@ async function main() {
     totalSupply.toString(),
     timeRemainingSeconds,
     unitSeconds,
-    ptDecimals[0]
+    ptDecimals[ptIndex]
   );
   console.log("\nPrincipal Token");
   console.log(`totalSupply: ${totalSupply}`);

--- a/src/helpers/calcSpotPrice.ts
+++ b/src/helpers/calcSpotPrice.ts
@@ -19,10 +19,16 @@ export function calcSpotPricePt(
   ptReserves: string,
   totalSupply: string,
   timeRemainingSeconds: number,
-  tParamSeconds: number
+  tParamSeconds: number,
+  decimals: number
 ): number {
+  // normalize decimal places of precision to 18
+  const diff = 18 - decimals;
+  const normalizedBaseReserves = +baseReserves * 10 ** diff;
+  const normalizedPtReserves = +ptReserves * 10 ** diff;
+
   const t = timeRemainingSeconds / tParamSeconds;
-  return (+baseReserves / (+ptReserves + +totalSupply)) ** t;
+  return (normalizedBaseReserves / (normalizedPtReserves + +totalSupply)) ** t;
 }
 
 export function calcSpotPriceYt(

--- a/src/helpers/calcSpotPrice.ts
+++ b/src/helpers/calcSpotPrice.ts
@@ -23,6 +23,10 @@ export function calcSpotPricePt(
   decimals: number
 ): number {
   // normalize decimal places of precision to 18
+  if (decimals < 0 || decimals > 18) {
+    // return 0 if decimals fall outside the range between 0 and 18
+    return 0;
+  }
   const diff = 18 - decimals;
   const normalizedBaseReserves = +baseReserves * 10 ** diff;
   const normalizedPtReserves = +ptReserves * 10 ** diff;

--- a/src/helpers/getElementAddresses.ts
+++ b/src/helpers/getElementAddresses.ts
@@ -167,3 +167,21 @@ export async function getPoolIdByTermAddress(
   }
   return poolId;
 }
+
+/**
+ * Get base address for a given token
+ * @param deploymentAddresses The Deployment Addresses object
+ * @param tokenKey 
+ * @returns The base address 
+ */
+ export function getBaseTokenAddress(
+  deploymentAddresses: DeploymentAddresses,
+  tokenKey: string
+): string {
+  for (const token in deploymentAddresses.tokens) {
+    if (token == tokenKey) {
+      return deploymentAddresses.tokens[token];
+    }
+  }
+  return "";
+}

--- a/src/helpers/getElementAddresses.ts
+++ b/src/helpers/getElementAddresses.ts
@@ -171,10 +171,10 @@ export async function getPoolIdByTermAddress(
 /**
  * Get base address for a given token
  * @param deploymentAddresses The Deployment Addresses object
- * @param tokenKey 
- * @returns The base address 
+ * @param tokenKey
+ * @returns The base address
  */
- export function getBaseTokenAddress(
+export function getBaseTokenAddress(
   deploymentAddresses: DeploymentAddresses,
   tokenKey: string
 ): string {

--- a/test/calcSpotPriceTest.ts
+++ b/test/calcSpotPriceTest.ts
@@ -49,3 +49,23 @@ describe("calcSpotPrices", () => {
     expect(result).to.equal(0.0019499512512187196);
   });
 });
+
+describe("calcSpotPricesBadDecimal", () => {
+  it("should return spot price of 0"), () => {
+    const ptReserves = BigNumber.from("1000000000000000");
+    const baseReserves = BigNumber.from("1612400925773352");
+    const totalSupply = baseReserves.add(ptReserves);
+    const timeRemainingSeconds = THIRTY_DAYS_IN_SECONDS;
+    const timeStretch = 4;
+    const tParamSeconds = timeStretch * ONE_YEAR_IN_SECONDS;
+    const result = calcSpotPricePt(
+      baseReserves.toString(),
+      ptReserves.toString(),
+      totalSupply.toString(),
+      timeRemainingSeconds,
+      tParamSeconds,
+      42
+    );
+    expect(result).to.equal(0);
+  };
+})

--- a/test/calcSpotPriceTest.ts
+++ b/test/calcSpotPriceTest.ts
@@ -36,7 +36,8 @@ describe("calcSpotPrices", () => {
       ptReserves.toString(),
       totalSupply.toString(),
       timeRemainingSeconds,
-      tParamSeconds
+      tParamSeconds,
+      18
     );
     expect(result).to.equal(0.9835616438356164);
   });

--- a/test/calcSpotPriceTest.ts
+++ b/test/calcSpotPriceTest.ts
@@ -51,21 +51,22 @@ describe("calcSpotPrices", () => {
 });
 
 describe("calcSpotPricesBadDecimal", () => {
-  it("should return spot price of 0"), () => {
-    const ptReserves = BigNumber.from("1000000000000000");
-    const baseReserves = BigNumber.from("1612400925773352");
-    const totalSupply = baseReserves.add(ptReserves);
-    const timeRemainingSeconds = THIRTY_DAYS_IN_SECONDS;
-    const timeStretch = 4;
-    const tParamSeconds = timeStretch * ONE_YEAR_IN_SECONDS;
-    const result = calcSpotPricePt(
-      baseReserves.toString(),
-      ptReserves.toString(),
-      totalSupply.toString(),
-      timeRemainingSeconds,
-      tParamSeconds,
-      42
-    );
-    expect(result).to.equal(0);
-  };
-})
+  it("should return spot price of 0"),
+    () => {
+      const ptReserves = BigNumber.from("1000000000000000");
+      const baseReserves = BigNumber.from("1612400925773352");
+      const totalSupply = baseReserves.add(ptReserves);
+      const timeRemainingSeconds = THIRTY_DAYS_IN_SECONDS;
+      const timeStretch = 4;
+      const tParamSeconds = timeStretch * ONE_YEAR_IN_SECONDS;
+      const result = calcSpotPricePt(
+        baseReserves.toString(),
+        ptReserves.toString(),
+        totalSupply.toString(),
+        timeRemainingSeconds,
+        tParamSeconds,
+        42
+      );
+      expect(result).to.equal(0);
+    };
+});


### PR DESCRIPTION
Fixes a bug in spot price calculation. Without taking into consideration the decimals of precision, our calculation for fixed APR can be way off (specifically for USDC).

Also adds a function to obtain the base token address for a given token. This is necessary to help the Twitter bot parse the addresses json in a much slicker fashion.

Resolves #20 