### PR TITLE
Fix `getTermByTokenSymbol`

### DIFF
--- a/src/helpers/getTermByTokenSymbol.ts
+++ b/src/helpers/getTermByTokenSymbol.ts
@@ -39,24 +39,24 @@ export async function getTermByTokenSymbol(
   signerOrProvider: Signer | Provider
 ): Promise<string> {
   const symbolsList: TermAddressSymbols[] = await Promise.all(
-    termAddresses.map(async (termAddress) => {
+    termAddresses.map(async (termAddress): Promise<TermAddressSymbols> => {
       const { principalTokenSymbol, yieldTokenSymbol }: TermTokenSymbolsResult =
         await getTermTokenSymbols(termAddress, signerOrProvider);
 
-      return <TermAddressSymbols>{
-        termAddress: termAddress,
-        principalTokenSymbol: principalTokenSymbol,
-        yieldTokenSymbol: yieldTokenSymbol,
+      return {
+        termAddress,
+        principalTokenSymbol,
+        yieldTokenSymbol,
       };
     })
   );
   return termAddresses.find((t) => {
     // get the symbols of a particular term address
-    const term = symbolsList.find(({ termAddress }) => termAddress == t)!;
+    const term = symbolsList.find(({ termAddress }) => termAddress == t);
 
     return (
-      term.principalTokenSymbol == tokenSymbol ||
-      term.yieldTokenSymbol == tokenSymbol
+      term?.principalTokenSymbol == tokenSymbol ||
+      term?.yieldTokenSymbol == tokenSymbol
     );
   }) as string;
 }

--- a/src/helpers/getTermByTokenSymbol.ts
+++ b/src/helpers/getTermByTokenSymbol.ts
@@ -32,13 +32,25 @@ export async function getTermByTokenSymbol(
   tokenSymbol: string,
   signerOrProvider: Signer | Provider
 ): Promise<string> {
-  return termAddresses.find(async (termAddress) => {
+  const symbolsList = await Promise.all(
+    termAddresses.map(async (termAddress) => {
+      const { principalTokenSymbol, yieldTokenSymbol }: TermTokenSymbolsResult =
+        await getTermTokenSymbols(termAddress, signerOrProvider);
+
+      return {
+        termAddress: termAddress,
+        principalTokenSymbol: principalTokenSymbol,
+        yieldTokenSymbol: yieldTokenSymbol,
+      };
+    })
+  );
+  return termAddresses.find((t) => {
     // get the symbols of a particular term address
-    const termTokenSymbols: TermTokenSymbolsResult = await getTermTokenSymbols(
-      termAddress,
-      signerOrProvider
+    const term = symbolsList.find(({ termAddress }) => termAddress == t)!;
+
+    return (
+      term.principalTokenSymbol == tokenSymbol ||
+      term.yieldTokenSymbol == tokenSymbol
     );
-    termTokenSymbols.principalTokenSymbol == tokenSymbol ||
-      termTokenSymbols.yieldTokenSymbol == tokenSymbol;
   }) as string;
 }

--- a/src/helpers/getTermByTokenSymbol.ts
+++ b/src/helpers/getTermByTokenSymbol.ts
@@ -21,9 +21,9 @@ import {
 } from "./getTermTokenSymbols";
 
 interface TermAddressSymbols {
-  termAddress: string,
-  principalTokenSymbol: string,
-  yieldTokenSymbol: string
+  termAddress: string;
+  principalTokenSymbol: string;
+  yieldTokenSymbol: string;
 }
 
 /**

--- a/src/helpers/getTermByTokenSymbol.ts
+++ b/src/helpers/getTermByTokenSymbol.ts
@@ -20,6 +20,12 @@ import {
   TermTokenSymbolsResult,
 } from "./getTermTokenSymbols";
 
+interface TermAddressSymbols {
+  termAddress: string,
+  principalTokenSymbol: string,
+  yieldTokenSymbol: string
+}
+
 /**
  * returns the term matching a token symbol
  * @param termAddresses array of terms addresses
@@ -32,12 +38,12 @@ export async function getTermByTokenSymbol(
   tokenSymbol: string,
   signerOrProvider: Signer | Provider
 ): Promise<string> {
-  const symbolsList = await Promise.all(
+  const symbolsList: TermAddressSymbols[] = await Promise.all(
     termAddresses.map(async (termAddress) => {
       const { principalTokenSymbol, yieldTokenSymbol }: TermTokenSymbolsResult =
         await getTermTokenSymbols(termAddress, signerOrProvider);
 
-      return {
+      return <TermAddressSymbols>{
         termAddress: termAddress,
         principalTokenSymbol: principalTokenSymbol,
         yieldTokenSymbol: yieldTokenSymbol,


### PR DESCRIPTION
`Array.find` doesn't expect a Promise to be returned so it will return always the first element.

Requesting and logging any term address (on Görli network)  using the old version of `getTermByTokenSymbol` would always return `0x80272c960b862B4d6542CDB7338Ad1f727E0D18d` (the `eP:eyUSDC:06-AUG-21-GMT` term address).